### PR TITLE
added reql:src/1, reql:desc/1 (from jstimpon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ gen_rethink_session:get_connection(my_session_name).
 
 The return value will be either `{ok, Connection}` or `{error, no_connection}`.
 
+To start a persistent connection for eunit tests, include this in your setup fixture: 
+```
+start() ->
+    gen_rethink_session:start_link(my_session_name,#{}).
+```
+
 Creating a ReQL query
 ---------------------
 Since Erlang doesn't support chaining function calls, ReQL queries are created

--- a/src/ql2.erl
+++ b/src/ql2.erl
@@ -26,6 +26,10 @@ datum({{A, B, C}, Timezone}) when is_integer(A) andalso
        timezone => Timezone };
 datum({iso8601, X}) ->
     [ql2:term_type(wire, iso8601), [X]];
+datum({desc, X}) ->
+    [ql2:term_type(wire, desc), [X]];
+datum({asc, X}) ->
+    [ql2:term_type(wire, asc), [X]];
 datum({binary, Blob}) ->
     #{ '$reql_type$' => <<"BINARY">>,
        data => base64:encode(Blob) };

--- a/src/reql.erl
+++ b/src/reql.erl
@@ -35,7 +35,7 @@
 -export([map/2, map/3, map/4, map/5, with_fields/2, with_fields/3, with_fields/4,
          with_fields/5, concat_map/2, order_by/2, order_by/3, skip/2, limit/2,
          slice/2, slice/3, slice/4, nth/2, offsets_of/2, is_empty/1, union/2,
-         union/3, sample/2]).
+         union/3, sample/2, desc/1, asc/1]).
 
 % Aggregation
 -export([group/2, group/3, ungroup/1, reduce/2, reduce/3, fold/3, fold/4, count/1,
@@ -230,6 +230,8 @@ db(DB) ->
 ?REQL1(union).
 ?REQL1_O(union).
 ?REQL1(sample).
+desc(X) -> {desc, X}.
+asc(X) -> {asc, X}.
 
 % Aggregation
 ?REQL1(group).


### PR DESCRIPTION
example usage: 
```
   {ok, R} = gen_rethink:run(Connection,
                              fun(X) ->
                                      reql:db(X, dog),
                                      reql:table(X, zone),
                                      reql:filter(X,#{name => Name}),
                                      reql:order_by(X, reql:desc(<<"created">>) ),
                                      reql:nth(X,0)
                              end),
    {ok, R}.
```
